### PR TITLE
added daphne.bin to emulator names (latest daphne install changed the…

### DIFF
--- a/bgm/MusicStateMachine.py
+++ b/bgm/MusicStateMachine.py
@@ -45,7 +45,7 @@ class MusicStateMachine:
 
         self._emulationstation_procname = forced_es_process or "emulationstatio"
         self._emulator_names = forced_emulators or ["retroarch", "ags", "uae4all2", "uae4arm", "capricerpi", "linapple", "hatari", "stella",
-                              "atari800", "xroar", "vice", "daphne", "reicast", "pifba", "osmose", "gpsp", "jzintv",
+                              "atari800", "xroar", "vice", "daphne", "daphne.bin", "reicast", "pifba", "osmose", "gpsp", "jzintv",
                               "basiliskll", "mame", "advmame", "dgen", "openmsx", "mupen64plus", "gngeo", "dosbox",
                               "ppsspp", "simcoupe", "scummvm", "snes9x", "pisnes", "frotz", "fbzx", "fuse", "gemrb",
                               "cgenesis", "zdoom", "eduke32", "lincity", "love", "kodi", "alephone", "micropolis",


### PR DESCRIPTION
… name of the process)

I was wondering if it would be possible to add a setting like "AdditionalEmulators" in the settings users could modify to include additional processes without needing to change the script/update?